### PR TITLE
Feature request: Option for skipping recent artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ GITHUB_REPOSITORY=<owner/repo>
 GITHUB_ACTION=<id>
 AGE="1 seconds"
 SKIP_TAGS=<yes/no like value>
+SKIP_RECENT=<number>

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,6 +32,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         age: '1 second'
         skip-tags: true
+        skip-recent: 1
 
   create-test-artifact:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ jobs:
       uses: c-hive/gha-remove-artifacts@v1
       with:
         age: '1 month'
-        skip-tags: true
+        # Optional inputs
+        # skip-tags: true
+        # skip-recent: 5
 ```
 
 ## Conventions

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     description: 'true/false. If enabled, tag build artifacts (e.g. release artifacts) will be kept.'
     required: false
   skip-recent:
-    description: 'Keep the specified number of artifacts even if they're older than the age.'
+    description: 'Keep the specified number of artifacts even if they are older than the age.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,3 +15,6 @@ inputs:
   skip-tags:
     description: 'true/false. If enabled, tag build artifacts (e.g. release artifacts) will be kept.'
     required: false
+  skip-recent:
+    description: 'Keep the specified number of artifacts even if they're older than the age.'
+    required: false

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ function getConfigs() {
     ")"
   );
 
+  console.log(core.getInput("skip-recent"));
+
   return {
     repo: {
       owner,
@@ -39,6 +41,7 @@ function getConfigs() {
     skipTags: devEnv
       ? yn(process.env.SKIP_TAGS)
       : yn(core.getInput("skip-tags")),
+    skipRecent: core.getInput("skip-recent"),
     retriesEnabled: true,
   };
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const yn = require("yn");
 
 const devEnv = process.env.NODE_ENV === "dev";
 
-const optionKeys = {
+const inputKeys = {
   AGE: devEnv ? "AGE" : "age",
   SKIP_TAGS: devEnv ? "SKIP_TAGS" : "skip-tags",
   SKIP_RECENT: devEnv ? "SKIP_RECENT" : "skip-recent",
@@ -17,7 +17,7 @@ if (devEnv) {
   require("dotenv-safe").config();
 }
 
-function readOption(key, isRequired = false) {
+function readInput(key, isRequired = false) {
   if (devEnv) {
     return process.env[key];
   }
@@ -27,7 +27,7 @@ function readOption(key, isRequired = false) {
 
 function getConfigs() {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-  const [age, units] = readOption(optionKeys.AGE, true).split(" ");
+  const [age, units] = readInput(inputKeys.AGE, true).split(" ");
   const maxAge = moment().subtract(age, units);
 
   console.log(
@@ -39,7 +39,7 @@ function getConfigs() {
     ")"
   );
 
-  const skipRecent = readOption(optionKeys.SKIP_RECENT);
+  const skipRecent = readInput(inputKeys.SKIP_RECENT);
 
   if (skipRecent) {
     const parsedRecent = Number(skipRecent);
@@ -58,7 +58,7 @@ function getConfigs() {
       perPage: 100,
     },
     maxAge: moment().subtract(age, units),
-    skipTags: yn(readOption(optionKeys.SKIP_TAGS)),
+    skipTags: yn(readInput(inputKeys.SKIP_TAGS)),
     skipRecent: Number(skipRecent),
     retriesEnabled: true,
   };

--- a/index.js
+++ b/index.js
@@ -18,10 +18,6 @@ if (devEnv) {
 }
 
 function readOption(key, isRequired = false) {
-  if (!optionKeys[key]) {
-    throw new Error(`${key} does not exist on the available options.`);
-  }
-
   if (devEnv) {
     return process.env[key];
   }


### PR DESCRIPTION
Issue #26.

Changes:
- the `skip-recent` option allows users to define the number of artifacts that should be prevented from the removal (even if they're older than the specified `age`)
- improvements (log the artifact's name alongside its id, created a map of the available options)