### PR TITLE
using: node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Remove artifacts'
 author: 'c-hive'
 description: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 inputs:
   age:


### PR DESCRIPTION
Fix Warning: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: c-hive/gha-remove-artifacts@v1.3.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.