### PR TITLE
chore: update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Remove artifacts'
 author: 'c-hive'
 description: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 inputs:
   age:


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node.js 20 on **June 2nd 2026**. This PR updates the action runtime in `action.yml` from `node20` to `node24` to ensure continued compatibility.

## Changes

- Updated `runs.using` in `action.yml` from `'node20'` to `'node24'`

## Context

GitHub Actions runners are transitioning away from Node.js 20. Actions that still declare `node20` as their runtime will start receiving deprecation warnings and will eventually fail. This change ensures the action continues to work seamlessly.

The existing bundled code in `dist/` uses standard Node.js APIs and Octokit libraries that are compatible with Node.js 24, so no source code changes are needed.

## References

- [GitHub Actions: Node.js 20 deprecation notice](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)